### PR TITLE
add banner to support hello-world content

### DIFF
--- a/sledgehammer.ks
+++ b/sledgehammer.ks
@@ -19,6 +19,7 @@ OpenIPMI-tools
 aic94xx-firmware
 audit
 authconfig
+banner
 basesystem
 bash
 bsdtar


### PR DESCRIPTION
- simply adds `banner` from epel release 

used in hello-world training content